### PR TITLE
Added and tested I2S support

### DIFF
--- a/esp8266_artnet_dmx512.ino
+++ b/esp8266_artnet_dmx512.ino
@@ -6,11 +6,18 @@
 
 */
 
-// Uncomment to send DMX data via I2S instead of USART (serial).
-// Using I2S allows for better control of number of stop bits and DMX specific timing
-// because DMA is used to send the data which does not strain the CPU and is not affected
-// by background activity such as handling WiFi, interrupts etc.
+// Uncomment to send DMX data using the microcontroller's builtin UART.
+// This is the original way this sketch used to work and expects the max485 level
+// shifter to be connected to the pin that corresondents to Serial1.
+// On a Wemos D1 this is e.g. pin D4.
+#define ENABLE_UART
+
+// Uncomment to send DMX data via I2S instead of UART.
+// I2S allows for better control of number of stop bits and DMX timing.
+// Moreover using DMA reduces strain of the CPU and avoids issues with background 
+// activity such as handling WiFi, interrupts etc.
 #define ENABLE_I2S
+#define I2S_FREQUENCY_CORRECTION (0)
 
 #include <ESP8266WiFi.h>         // https://github.com/esp8266/Arduino
 #include <ESP8266WebServer.h>
@@ -34,6 +41,8 @@
 // #define COMMON_ANODE
 
 Config config;
+
+
 ESP8266WebServer server(80);
 const char* host = "ARTNET";
 const char* version = __DATE__ " / " __TIME__;
@@ -41,27 +50,39 @@ const char* version = __DATE__ " / " __TIME__;
 #define LED_B 16  // GPIO16/D0
 #define LED_G 5   // GPIO05/D1
 #define LED_R 4   // GPIO04/D2
+
 #ifdef ENABLE_I2S
 #define I2S_PIN 3
 #endif
 
 // Artnet settings
 ArtnetWifi artnet;
+
+
 unsigned long packetCounter = 0, frameCounter = 0;
 float fps = 0;
 
 #ifdef ENABLE_I2S
 
 #define DMX_CHANNELS 512
-// Global buffer to I2S definition of DMX data
+
+// 
+//#define SHORT_SPACE_FOR_BREAK
+// Below timings are based on measures taken with a commercial DMX512 controller.
 struct {
-  uint16_t mark_before_break[10]; // 2 * 80 bits * 4 us/bit = 640us
-  uint16_t space_for_break[2];    // 32 bits * 4 us/bit = 128 us
-  uint16_t mark_after_break;      // 13 MSB will be injitialized to low and adds 52 us to space_for_break 180us
-  // each DMX "byte" (actually a word here because of extra stop bits) consists of:
+  uint16_t mark_before_break[10]; // 600us / 4us / 16 bits -> 640us
+  #ifdef SHORT_SPACE_FOR_BREAK
+  uint8_t space_for_break[3]; // 120us / 4us / 8 bits = 3.75
+  uint8_t mark_after_break;   // 5 MSB low bits * 4us adds 20us to space_for_break -> 116us
+  #else
+  uint16_t space_for_break[2]; // 120us / 4us / 16 bits -> 128 us
+  uint16_t mark_after_break; // 13 MSB low bits *4us adds 52us to space_for_break -> 180us
+  #endif
+  // each "byte" (actually a word) consists of:
   // 8 bits payload + 7 stop bits (high) + 1 start (low) for the next byte  
-  uint16_t dmx_bytes[DMX_CHANNELS+1]; // 0. bytes is the null/start byte => +1
+  uint16_t dmx_bytes[DMX_CHANNELS+1];
 } i2s_data;
+
 #endif
 
 // Global universe buffer
@@ -69,14 +90,24 @@ struct {
   uint16_t universe;
   uint16_t length;
   uint8_t sequence;
-  #ifdef ENABLE_I2S
+  // when using I2S, channel values are stored in i2s_data
+#ifdef ENABLE_UART
   uint8_t *data;
-  #endif
+#endif
 } global;
-
 
 // keep track of the timing of the function calls
 long tic_loop = 0, tic_fps = 0, tic_packet = 0, tic_web = 0;
+
+#ifdef ENABLE_UART
+long tic_uart = 0;
+unsigned long uartCounter;
+#endif
+
+#ifdef ENABLE_I2S
+long tic_i2s = 0;
+unsigned long i2sCounter;
+#endif
 
 //this will be called for each UDP packet received
 void onDmxPacket(uint16_t universe, uint16_t length, uint8_t sequence, uint8_t * data) {
@@ -95,8 +126,8 @@ void onDmxPacket(uint16_t universe, uint16_t length, uint8_t sequence, uint8_t *
 
   if (universe == config.universe) {
 
-    #ifdef ENABLE_I2S
-
+#ifdef ENABLE_I2S
+    // TODO optimize i2s such that it can send less than 512 bytes if not required
     for (int i=0; i<DMX_CHANNELS; i++) {
       uint16_t hi = i<length ? flipByte(data[i]) : 0;      
       // Add stop bits and start bit of next byte unless there is no next byte.
@@ -104,8 +135,9 @@ void onDmxPacket(uint16_t universe, uint16_t length, uint8_t sequence, uint8_t *
       // leave null/start byte untached => +1:
       i2s_data.dmx_bytes[i+1] = (hi<<8) | lo;
     }
+#endif
 
-    #else
+#ifdef ENABLE_UART
     
     // copy the data from the UDP packet over to the global universe buffer
     global.universe = universe;
@@ -115,24 +147,34 @@ void onDmxPacket(uint16_t universe, uint16_t length, uint8_t sequence, uint8_t *
     for (int i = 0; i < global.length; i++)
       global.data[i] = data[i];
 
-    #endif
+#endif
   }
 } // onDmxpacket
 
 
+
+long packets;
+long last;
+
+const int CONNECTION_TIMEOUT = 5;
+
+//#define WITH_TEST_CODE
+
 void setup() {
   
-  #ifdef ENABLE_I2S  
-  initI2S();
-  #else
+#ifdef ENABLE_UART
   Serial1.begin(250000, SERIAL_8N2);
-  #endif
-  
+#endif 
   Serial.begin(115200);
   while (!Serial) {
     ;
   }
   Serial.println("setup starting");
+
+  // Must NOT be called before Serial.begin (i@S output is on RX0 pin)
+#ifdef ENABLE_I2S  
+  initI2S();
+#endif
 
   pinMode(LED_R, OUTPUT);
   pinMode(LED_G, OUTPUT);
@@ -141,9 +183,11 @@ void setup() {
   global.universe = 0;
   global.sequence = 0;
   global.length = 512;
+#ifdef ENABLE_UART
   global.data = (uint8_t *)malloc(512);
   for (int i = 0; i < 512; i++)
     global.data[i] = 0;
+#endif
 
   SPIFFS.begin();
 
@@ -172,6 +216,160 @@ void setup() {
     singleGreen();
 
 #ifdef ENABLE_WEBINTERFACE
+    initServer();
+#endif
+
+  // announce the hostname and web server through zeroconf
+#ifdef ENABLE_MDNS
+  MDNS.begin(host);
+  MDNS.addService("http", "tcp", 80);
+#endif
+
+  artnet.begin();
+  artnet.setArtDmxCallback(onDmxPacket);
+
+  // initialize all timers
+  tic_loop   = millis();
+  tic_packet = millis();
+  tic_fps    = millis();
+  tic_web    = 0;
+
+#ifdef ENABLE_UART
+  tic_uart    = 0;
+#endif    
+#ifdef ENABLE_I2S
+  tic_i2s    = 0;
+#endif  
+
+  Serial.println("setup done");
+} // setup
+
+
+void loop() {
+  server.handleClient();
+
+  if (WiFi.status() != WL_CONNECTED) {
+    singleRed();
+    delay(10);
+  }
+  else if ((millis() - tic_web) < 5000) {
+    singleBlue();
+    delay(25);
+  }
+  else  {
+    singleGreen();
+    artnet.read();
+
+    // this section gets executed at a maximum rate of around 40Hz
+    if ((millis() - tic_loop) > config.delay) {
+      tic_loop = millis();
+      frameCounter++;
+
+#ifdef ENABLE_UART
+      outputSerial();
+#endif      
+
+#ifdef ENABLE_I2S
+      outputI2S();
+#endif      
+    }
+  }
+
+  delay(1);
+} // loop
+
+
+#ifdef ENABLE_UART
+
+void outputSerial() {
+
+  sendBreak();
+
+  Serial1.write(0); // Start-Byte
+  // send out the value of the selected channels (up to 512)
+  for (int i = 0; i < MIN(global.length, config.channels); i++) {
+    Serial1.write(global.data[i]);
+  }    
+
+  uartCounter++;
+  long now = millis();
+  if ((now - tic_uart) > 1000 && uartCounter > 100) {
+    // don't estimate the FPS too frequently
+    float pps = (1000.0 * uartCounter) / (now - tic_uart);
+    tic_uart = now;
+    uartCounter = 0;
+    Serial.printf("UART: %.1f p/s\n", pps);
+  }  
+}
+
+#endif
+
+#ifdef ENABLE_I2S
+
+void initI2S() {
+    pinMode(3, OUTPUT); // Override default Serial initiation
+    digitalWrite(3, 1); // Set pin high
+  
+    memset(&i2s_data, 0x00, sizeof(i2s_data));
+    memset(&(i2s_data.mark_before_break), 0xff, sizeof(i2s_data.mark_before_break));
+    
+    // 3 bits (12us) MAB. The MAB's LSB 0 acts as the start bit (low) for the null byte
+    i2s_data.mark_after_break = (uint16_t) 0b000001110;
+    
+    // Set LSB to 0 for every byte to act as the start bit of the following byte.
+    // Sending 7 stop bits in stead of 2 will please slow/buggy hardware and act
+    // as the mark time between slots.
+    for (int i=0; i<DMX_CHANNELS; i++) {
+      i2s_data.dmx_bytes[i] = (uint16_t) 0b0000000011111110;
+    }
+    // Set MSB NOT to 0 for the last byte because MBB (mark for break will follow)
+    i2s_data.dmx_bytes[DMX_CHANNELS] = (uint16_t) 0b0000000011111111;
+  
+    config.universe = 0;
+  
+    artnet.begin();
+    artnet.setArtDmxCallback(onDmxPacket);
+  
+    i2s_begin();
+    // 250.000 baud / 32 bits = 7812
+    i2s_set_rate(7812); 
+  
+    // Commment in this to fine tune frequency: should be 125 kHz (on oscillocope)
+    //memset(&data, 0b01010101, sizeof(data));
+}
+
+void outputI2S(void) {  
+  // From the comment in i2s.h: 
+  // "A frame is just a int16_t for mono, for stereo a frame is two int16_t, one for each channel."
+  // Therefore we need to divide by 4 in total
+  int frames = sizeof(i2s_data)/4;
+  i2s_write_buffer((int16_t*) &i2s_data, frames);
+
+  i2sCounter++;
+  long now = millis();
+  if ((now - tic_i2s) > 1000 && i2sCounter > 100) {
+    // don't estimate the FPS too frequently
+    float pps = (1000.0 * i2sCounter) / (now - tic_i2s);
+    tic_i2s = now;
+    i2sCounter = 0;
+    Serial.printf("I2S: %.1f p/s\n", pps);
+  }
+}
+
+// Reverse byte order because DMX expects LSB first but I2S sends MSB first.
+byte flipByte(byte c) {
+  c = ((c>>1)&0x55)|((c<<1)&0xAA);
+  c = ((c>>2)&0x33)|((c<<2)&0xCC);
+  c = (c>>4) | (c<<4) ;
+  return c;
+}
+
+#endif
+
+
+#ifdef ENABLE_WEBINTERFACE
+
+void initServer() {
   // this serves all URIs that can be resolved to a file on the SPIFFS filesystem
   server.onNotFound(handleNotFound);
 
@@ -276,106 +474,8 @@ void setup() {
 
   // start the web server
   server.begin();
-#endif
-
-  // announce the hostname and web server through zeroconf
-#ifdef ENABLE_MDNS
-  MDNS.begin(host);
-  MDNS.addService("http", "tcp", 80);
-#endif
-
-  artnet.begin();
-  artnet.setArtDmxCallback(onDmxPacket);
-
-  // initialize all timers
-  tic_loop   = millis();
-  tic_packet = millis();
-  tic_fps    = millis();
-  tic_web    = 0;
-
-  Serial.println("setup done");
-} // setup
-
-void loop() {
-  server.handleClient();
-
-  if (WiFi.status() != WL_CONNECTED) {
-    singleRed();
-    delay(10);
-  }
-  else if ((millis() - tic_web) < 5000) {
-    singleBlue();
-    delay(25);
-  }
-  else  {
-    singleGreen();
-    artnet.read();
-
-    // this section gets executed at a maximum rate of around 40Hz
-    if ((millis() - tic_loop) > config.delay) {
-      tic_loop = millis();
-      frameCounter++;
-
-      sendDmxValues();
-    }
-  }
-
-  delay(1);
-} // loop
-
-#ifdef ENABLE_I2S
-// Reverse byte order because DMX expects LSB first but I2S sends MSB first.
-byte flipByte(byte c) {
-  c = ((c>>1)&0x55)|((c<<1)&0xAA);
-  c = ((c>>2)&0x33)|((c<<2)&0xCC);
-  c = (c>>4) | (c<<4) ;
-  return c;
-}
-
-void initI2S() {
-  pinMode(I2S_PIN, OUTPUT);
-  digitalWrite(3, 1); // Set pin high  
-
-  memset(&i2s_data, 0x00, sizeof(i2s_data));
-  memset(&(i2s_data.mark_before_break), 0xff, sizeof(i2s_data.mark_before_break));
-  
-  // 3 bits (12us) MAB. The MAB's LSB 0 acts as the start bit (low) for the null byte
-  i2s_data.mark_after_break = (uint16_t) 0b000001110;
-  
-  // Set LSB to 0 for every byte to act as the start bit of the following byte.
-  // Sending 7 stop bits instead of 2 will please slow/buggy hardware and act
-  // as the mark time between slots.
-  for (int i=0; i<DMX_CHANNELS; i++) {
-    i2s_data.dmx_bytes[i] = (uint16_t) 0b0000000011111110;
-  }
-  // Set MSB NOT to 0 for the last byte because MBB (mark for break will follow).
-  // Note: No off-by-one bug here as the size of dmx_bytes is DMX_CHANNELS+1;
-  i2s_data.dmx_bytes[DMX_CHANNELS] = (uint16_t) 0b0000000011111111;
 }
 #endif
-
-void sendDmxValues() {
-
-  #ifdef ENABLE_I2S
-
-  // From the comment in i2s.h: 
-  // "A frame is just a int16_t for mono, for stereo a frame is two int16_t, one for each channel."
-  // Therefore we need to divide by 4 in total
-  i2s_write_buffer((int16_t*) &i2s_data, sizeof(i2s_data)/4);
-  
-  #else
-  
-  sendBreak();
-
-  Serial1.write(0); // Start-Byte
-  // send out the value of the selected channels (up to 512)
-  for (int i = 0; i < MIN(global.length, config.channels); i++) {
-    Serial1.write(global.data[i]);
-  }  
-  
-  #endif
-}
-
 
 #ifdef COMMON_ANODE
 

--- a/esp8266_artnet_dmx512.ino
+++ b/esp8266_artnet_dmx512.ino
@@ -10,14 +10,14 @@
 // This is the original way this sketch used to work and expects the max485 level
 // shifter to be connected to the pin that corresondents to Serial1.
 // On a Wemos D1 this is e.g. pin D4.
-//#define ENABLE_UART
+#define ENABLE_UART
 
 // Uncomment to send DMX data via I2S instead of UART.
 // I2S allows for better control of number of stop bits and DMX timing.
 // Moreover using DMA reduces strain of the CPU and avoids issues with background 
 // activity such as handling WiFi, interrupts etc.
-#define ENABLE_I2S
-#define I2S_FREQUENCY_CORRECTION (0)
+// #define ENABLE_I2S
+// #define I2S_FREQUENCY_CORRECTION (0)
 
 // Enable kind of unit test for new I2S code moving around a knowingly picky device 
 // (china brand moving head with timing issues)

--- a/esp8266_artnet_dmx512.ino
+++ b/esp8266_artnet_dmx512.ino
@@ -23,9 +23,11 @@
 #define ENABLE_UART
 
 // Uncomment to send DMX data via I2S instead of UART.
-// I2S allows for better control of number of stop bits and DMX timing.
-// Moreover using DMA reduces strain of the CPU and avoids issues with background
-// activity such as handling WiFi, interrupts etc.
+// I2S allows for better control of number of stop bits and DMX timing to meet the
+// requiremeents of sloppy devices. Moreover using DMA reduces strain of the CPU and avoids 
+// issues with background activity such as handling WiFi, interrupts etc.
+// However - because of the extra timing/pauses for sloppy device, sending DMX over I2S
+// will cause throughput to drop from approx 40 packets/s to around 30.
 //#define ENABLE_I2S
 
 // Enable kind of unit test for new I2S code moving around a knowingly picky device

--- a/esp8266_artnet_dmx512.ino
+++ b/esp8266_artnet_dmx512.ino
@@ -10,7 +10,7 @@
 // This is the original way this sketch used to work and expects the max485 level
 // shifter to be connected to the pin that corresondents to Serial1.
 // On a Wemos D1 this is e.g. pin D4.
-#define ENABLE_UART
+//#define ENABLE_UART
 
 // Uncomment to send DMX data via I2S instead of UART.
 // I2S allows for better control of number of stop bits and DMX timing.

--- a/i2s_dmx.h
+++ b/i2s_dmx.h
@@ -9,9 +9,9 @@
 // stop bits. Apparently to please some picky devices out there that cannot handle
 // DMX data quickly enough.
 typedef struct {
-  uint16_t mark_before_break[10]; // 10 * 16 bits * 4 us -> 640 us
-  uint16_t space_for_break[2]; // 2 * 16 bits * 4 us -> 128 us
-  uint16_t mark_after_break; // 13 MSB low bits * 4 us adds 52 us to space_for_break -> 180us
+  uint16_t mark_before_break[1]; // 1 * 16 bits * 4 us -> 64 us
+  uint16_t space_for_break[1];   // 1 * 16 bits * 4 us -> 64 us
+  uint16_t mark_after_break;     // 13 MSB low bits * 4 us adds 52 us to space_for_break -> 116 us
   // each "byte" (actually a word) consists of:
   // 8 bits payload + 7 stop bits (high) + 1 start (low) for the next byte  
   uint16_t dmx_bytes[DMX_CHANNELS+1];

--- a/i2s_dmx.h
+++ b/i2s_dmx.h
@@ -4,10 +4,29 @@
 #define I2S_PIN 3
 #define DMX_CHANNELS 512
 
+// See comments below
+//#define I2S_SUPER_SAFE
+
+#ifdef I2S_SUPER_SAFE
+
 // Below timings are based on measures taken with a commercial DMX512 controller.
 // They differ substentially from the offcial DMX standard ... breaks are longer, more
 // stop bits. Apparently to please some picky devices out there that cannot handle
 // DMX data quickly enough.
+// Using these parameters results in a throughput of approx. 29.7 packets/s (with 512 DMX channels)
+typedef struct {
+  uint16_t mark_before_break[10]; // 10 * 16 bits * 4 us -> 640 us
+  uint16_t space_for_break[2];   // 2 * 16 bits * 4 us -> 128 us
+  uint16_t mark_after_break;     // 13 MSB low bits * 4 us adds 52 us to space_for_break -> 180 us
+  // each "byte" (actually a word) consists of:
+  // 8 bits payload + 7 stop bits (high) + 1 start (low) for the next byte  
+  uint16_t dmx_bytes[DMX_CHANNELS+1];
+} i2s_packet;
+
+#else 
+
+// This configuration sets way shorter MBB and SFB but still adds lots of extra stop bits.
+// At least for my devices this still works and increases thrughput slightly to 30.3  packets/s. 
 typedef struct {
   uint16_t mark_before_break[1]; // 1 * 16 bits * 4 us -> 64 us
   uint16_t space_for_break[1];   // 1 * 16 bits * 4 us -> 64 us
@@ -17,4 +36,30 @@ typedef struct {
   uint16_t dmx_bytes[DMX_CHANNELS+1];
 } i2s_packet;
 
+void logI2SInfo() {
+#ifdef I2S_SUPER_SAFE
+  Serial.println("Using super safe I2S timing");
+#else
+  Serial.println("Using normal I2S timing");
+#endif    
+}
+// TODO try to reduce number of stop bits
+/* 
+ E.g. as below with 3 stop bits. However, it's questionable if that still will work with sloppy devices,
+ because it's not a lot more than what DMX requires (2 stop bits). Moreover we'd need to somehow 
+ persuade the compiler not to align the data at word limits in memory.
+struct {
+  uint16_t startbit1 : 1;
+  uint16_t payload1  : 8;
+  uint16_t stopbits1 : 3; 
+  // 8+3+1 = 12
+  uint16_t startbit2 : 1;
+  uint16_t payload2  : 8;
+  uint16_t stopbits1 : 3; 
+  // 8+3+1 = 12
+  // 12 + 12 = 24 = 3 bytes
+}
+*/
 #endif
+
+#endif // _I2S_DMX_H_

--- a/i2s_dmx.h
+++ b/i2s_dmx.h
@@ -1,0 +1,20 @@
+#ifndef _I2S_DMX_H_
+#define _I2S_DMX_H_
+
+#define I2S_PIN 3
+#define DMX_CHANNELS 512
+
+// Below timings are based on measures taken with a commercial DMX512 controller.
+// They differ substentially from the offcial DMX standard ... breaks are longer, more
+// stop bits. Apparently to please some picky devices out there that cannot handle
+// DMX data quickly enough.
+typedef struct {
+  uint16_t mark_before_break[10]; // 10 * 16 bits * 4 us -> 640 us
+  uint16_t space_for_break[2]; // 2 * 16 bits * 4 us -> 128 us
+  uint16_t mark_after_break; // 13 MSB low bits * 4 us adds 52 us to space_for_break -> 180us
+  // each "byte" (actually a word) consists of:
+  // 8 bits payload + 7 stop bits (high) + 1 start (low) for the next byte  
+  uint16_t dmx_bytes[DMX_CHANNELS+1];
+} i2s_packet;
+
+#endif


### PR DESCRIPTION
Hi Robert.
Sorry for the delay but my Artnet device broke recently (physically - the power supply inside the housing stopped working).
So I had to wait for the delivery of some spare parts and tinker everything togther.
Today I managed to repair it and ported my former "proof of concept" code to my fork of your repo.
There are two #defines right at the top of the main file that will control the way how DMX data is sent.
I found today that it seems to be possible to send it even in parallel on I2S *and* UART.
However, as I2S will slow down throughput to approx. 30 frames/s on both channels, I disabled it by default.
There's a TODO left regarding when less than 512 channels were received. 
I can fix that soon and some experiments have shown so far that if e.g. reducing to 256 will bring back the frame rate to 40 or so. But for now, I wanted to have something quick and stable that does not blow up the code.
I also extracted some lenghty code to methods to increase readability.

